### PR TITLE
feat(index): add ability to return a `{Promise}` from the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ module.exports = (ctx) => ({
 })
 ```
 
+You also can export a `{Promise}` that resolves the config either as an `{Object}`
+or a `{Function}` that returns the config.
+
+**.postcssrc.js**
+```js
+module.exports = readFile(file, 'utf8')
+  .then(JSON.parse)
+  .then((data) => (ctx) => ({
+    parser: data.parser,
+    map: ctx.env === 'development' ? ctx.map : false,
+    plugins: {
+      'postcss-plugin': ctx.options.plugin
+    }
+  }))
+```
+
 Plugins can be loaded either using an `{Object}` or an `{Array}`
 
 #### `{Object}`

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,10 @@ const rc = (ctx, path, options) => {
         throw new Error(`No PostCSS Config found in: ${path}`)
       }
 
+      return Promise.resolve(result.config)
+        .then((config) => Object.assign({}, result, { config }))
+    })
+    .then((result) => {
       let file = result.filepath || ''
       let config = result.config || {}
 

--- a/test/js.test.js
+++ b/test/js.test.js
@@ -112,3 +112,44 @@ test('postcss.config.js - {Array} - Process SSS', () => {
       })
   })
 })
+
+test('postcss.config.js - {Promise<Function>} - Load Config', () => {
+  const ctx = {
+    parser: true,
+    syntax: true
+  }
+
+  return postcssrc(ctx, 'test/js/promise/function').then((config) => {
+    expect(config.options.parser).toEqual(require('sugarss'))
+    expect(config.options.syntax).toEqual(require('sugarss'))
+    expect(config.options.map).toEqual(false)
+    expect(config.options.from).toEqual('./test/js/promise/function/fixtures/index.css')
+    expect(config.options.to).toEqual('./test/js/promise/function/expect/index.css')
+
+    expect(config.plugins.length).toEqual(2)
+    expect(typeof config.plugins[0]).toBe('function')
+    expect(typeof config.plugins[1]).toBe('function')
+
+    expect(config.file).toEqual(
+      path.resolve('test/js/promise/function', 'postcss.config.js')
+    )
+  })
+})
+
+test('postcss.config.js - {Promise<Object>} - Load Config', () => {
+  return postcssrc({}, 'test/js/promise/object').then((config) => {
+    expect(config.options.parser).toEqual(require('sugarss'))
+    expect(config.options.syntax).toEqual(require('sugarss'))
+    expect(config.options.map).toEqual('inline')
+    expect(config.options.from).toEqual('./test/js/promise/object/fixtures/index.css')
+    expect(config.options.to).toEqual('./test/js/promise/object/expect/index.css')
+
+    expect(config.plugins.length).toEqual(2)
+    expect(typeof config.plugins[0]).toBe('function')
+    expect(typeof config.plugins[1]).toBe('function')
+
+    expect(config.file).toEqual(
+      path.resolve('test/js/promise/object', 'postcss.config.js')
+    )
+  })
+})

--- a/test/js/promise/function/postcss.config.js
+++ b/test/js/promise/function/postcss.config.js
@@ -1,0 +1,14 @@
+module.exports = Promise.resolve(function (ctx) {
+  return {
+    parser: ctx.parser ? 'sugarss' : false,
+    syntax: ctx.syntax ? 'sugarss' : false,
+    map: ctx.map ? 'inline' : false,
+    from: './test/js/promise/function/fixtures/index.css',
+    to: './test/js/promise/function/expect/index.css',
+    plugins: {
+      'postcss-import': {},
+      'postcss-nested': {},
+      'cssnano': ctx.env === 'production' ? {} : false
+    }
+  }
+})

--- a/test/js/promise/object/postcss.config.js
+++ b/test/js/promise/object/postcss.config.js
@@ -1,0 +1,12 @@
+module.exports = Promise.resolve({
+  parser: 'sugarss',
+  syntax: 'sugarss',
+  map: 'inline',
+  from: './test/js/promise/object/fixtures/index.css',
+  to: './test/js/promise/object/expect/index.css',
+  plugins: {
+    'postcss-import': {},
+    'postcss-nested': {},
+    'cssnano': false
+  }
+})


### PR DESCRIPTION
This PR adds an ability to return a Promise from the config:

```js
module.exports = readFile(someFile, 'utf8')
  .then(JSON.parse)
  .then((someData) => (ctx) => ({
    parser: someData.parser,
    map: ctx.env === 'development' ? ctx.map : false,
    plugins: {
      'postcss-plugin': ctx.options.plugin
    }
  }))
```

It enables advanced configuration, for example, syncing with webpack config:

```js
const configPromise = getWebpackConfig().then(webpackConfig => {
  const resolver = ResolverFactory.createResolver({
    alias: webpackConfig.resolve.alias
  })

  return {
    plugins: [
      require('postcss-import')({
        resolve: (id, basedir) => resolver.resolveSync({}, basedir, id)
      })
    ]
  }
})
module.exports = configPromise
```

I also had to update Jest because it was throwing `SecurityError: localStorage is not available for opaque origins`. See for more details: https://github.com/facebook/jest/issues/6766.