### PR TITLE
chore: drop import-cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "https://opencollective.com/postcss/"
   },
   "dependencies": {
-    "import-cwd": "^3.0.0",
     "lilconfig": "^2.0.3",
     "yaml": "^1.10.2"
   },

--- a/src/options.js
+++ b/src/options.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const { createRequire } = require('module')
+// eslint-disable-next-line node/no-deprecated-api
+const { createRequire, createRequireFromPath } = require('module')
 const path = require('path')
-const req = createRequire(path.resolve(process.cwd(), '_'))
+const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))
 
 /**
  * Load Options

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const req = require('import-cwd')
+const { createRequire } = require('module')
+const path = require('path')
+const req = createRequire(path.resolve(process.cwd(), '_'))
 
 /**
  * Load Options

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const req = require('import-cwd')
+const { createRequire } = require('module')
+const path = require('path')
+const req = createRequire(path.resolve(process.cwd(), '_'))
 
 /**
  * Plugin Loader

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const { createRequire } = require('module')
+// eslint-disable-next-line node/no-deprecated-api
+const { createRequire, createRequireFromPath } = require('module')
 const path = require('path')
-const req = createRequire(path.resolve(process.cwd(), '_'))
+const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))
 
 /**
  * Plugin Loader


### PR DESCRIPTION
@ai up to you if you want this or not ofc.

basically we introduced import-cwd at some point which is arguably fairly redundant since we can just use the built in node functions for this directly. personally don't see the point in these one-liner packages.

by dropping it, you can reduce the dependencies tree by at least 2-3 packages (surprisingly for something so simple).

let me know if you agree

### `Type`

- [ ] CI
- [ ] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [x] Chore
- [ ] Style
- [ ] Build
- [ ] Feature
- [ ] Refactor

### `SemVer`

- [x] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
