### PR TITLE
fix: load PostCSS plugins based on the current file path instead of process.cwd()

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,12 @@ module.exports = (env) => ({
       <br />
       <a href="https://github.com/daltones">Dalton Santos</a>
     </td>
+    <td align="center">
+      <img width="150" height="150"
+        src="https://github.com/fwouts.png?v=3&s=150">
+      <br />
+      <a href="https://github.com/fwouts">François Wouts</a>
+    </td>
   </tr>
   <tbody>
 </table>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "Ryan Dunckel",
     "Mateusz Derks",
     "Dalton Santos",
-    "Patrick Gilday"
+    "Patrick Gilday",
+    "François Wouts"
   ],
   "repository": "postcss/postcss-load-config",
   "license": "MIT"

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,6 @@
 'use strict'
 
-// eslint-disable-next-line node/no-deprecated-api
-const { createRequire, createRequireFromPath } = require('module')
-const path = require('path')
-const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))
+const req = require('./req.js')
 
 /**
  * Load Options
@@ -18,7 +15,7 @@ const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(),
 const options = (config, file) => {
   if (config.parser && typeof config.parser === 'string') {
     try {
-      config.parser = req(config.parser)
+      config.parser = req(config.parser, file)
     } catch (err) {
       throw new Error(`Loading PostCSS Parser failed: ${err.message}\n\n(@${file})`)
     }
@@ -26,7 +23,7 @@ const options = (config, file) => {
 
   if (config.syntax && typeof config.syntax === 'string') {
     try {
-      config.syntax = req(config.syntax)
+      config.syntax = req(config.syntax, file)
     } catch (err) {
       throw new Error(`Loading PostCSS Syntax failed: ${err.message}\n\n(@${file})`)
     }
@@ -34,7 +31,7 @@ const options = (config, file) => {
 
   if (config.stringifier && typeof config.stringifier === 'string') {
     try {
-      config.stringifier = req(config.stringifier)
+      config.stringifier = req(config.stringifier, file)
     } catch (err) {
       throw new Error(`Loading PostCSS Stringifier failed: ${err.message}\n\n(@${file})`)
     }

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,9 +1,6 @@
 'use strict'
 
-// eslint-disable-next-line node/no-deprecated-api
-const { createRequire, createRequireFromPath } = require('module')
-const path = require('path')
-const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))
+const req = require('./req.js')
 
 /**
  * Plugin Loader
@@ -23,9 +20,9 @@ const load = (plugin, options, file) => {
       options === undefined ||
       Object.keys(options).length === 0
     ) {
-      return req(plugin)
+      return req(plugin, file)
     } else {
-      return req(plugin)(options)
+      return req(plugin, file)(options)
     }
   } catch (err) {
     throw new Error(`Loading PostCSS Plugin failed: ${err.message}\n\n(@${file})`)

--- a/src/req.js
+++ b/src/req.js
@@ -1,0 +1,7 @@
+// eslint-disable-next-line node/no-deprecated-api
+const { createRequire, createRequireFromPath } = require('module')
+const path = require('path')
+
+const req = (moduleId, file) => (createRequire || createRequireFromPath)(path.resolve(file, '_'))(moduleId)
+
+module.exports = req


### PR DESCRIPTION
### `Notable Changes`

<!-- ✏️ Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue down below -->

Currently, postcss-load-config can only work when the desired PostCSS plugins can be loaded from `process.cwd()`. It does not work, for example, when postcss-load-config is used to load a PostCSS config file from a different directory, and that PostCSS config file uses a plugin that isn't available in the current working directory.

Until https://github.com/postcss/postcss-load-config/pull/227, a workaround was to call `process.chdir()` before invoking postcss-load-config, as it would appropriately update the require path and find the PostCSS plugins. This workaround was discussed in https://github.com/vitejs/vite/issues/4000 for example.

Since https://github.com/postcss/postcss-load-config/pull/227, `process.cwd()` is invoked once at module initialisation time, which is a subtly different behaviour from `import-cwd` which invoked `process.cwd()` repeatedly on every require (see https://github.com/sindresorhus/import-cwd/blob/8e204cbf8b4fc0743e4ebeebd0acfbbd17fee87b/index.js#L4). This broke the workaround of calling `process.chdir()` since it would have no effect on later invocations of postcss-load-config.

A better approach was suggested by @43081j in https://github.com/vitejs/vite/issues/4000#issuecomment-1005655018, which relies on using the PostCSS config file as the search path for loading PostCSS plugins, instead of `process.cwd()`. This seems sensible, and all tests pass, but I may be missing a subtle requirement here.

If this behaviour isn't desirable, we could at least restore the old workaround by replacing:
```js
const req = (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))
```
with:
```js
const req = moduleId => (createRequire || createRequireFromPath)(path.resolve(process.cwd(), '_'))(moduleId)
```
(effectively deferring the call to `process.cwd()`)

#### `Commit Message Summary (CHANGELOG)`

```
fix: load plugins from postcss config path instead of current working directory
```

### `Type`

<!-- ℹ️  What types of changes does your code introduce? -->

<!-- 👉 Put an `x` in the boxes that apply and delete all others -->

- [ ] CI
- [x] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Style
- [ ] Build
- [ ] Feature
- [x] Refactor

### `SemVer`

<!-- ℹ️  What changes to the current `semver` range does your PR introduce? -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [x] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Issues`

<!-- ℹ️ What issue(s) (if any) are closed by your PR? -->

<!-- 👉  Replace `#1` with the issue number that applies and remove the ``` ` ``` -->

- Fixes https://github.com/vitejs/vite/issues/4000

### `Checklist`

<!-- ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
