### PR TITLE
change `req` to resolve based on file path rather than directory

### DIFF
--- a/src/req.js
+++ b/src/req.js
@@ -1,10 +1,9 @@
 // eslint-disable-next-line node/no-deprecated-api
 const { createRequire, createRequireFromPath } = require('module')
-const path = require('path')
 
 function req (name, rootFile) {
   const create = createRequire || createRequireFromPath
-  const require = create(path.resolve(rootFile, '_'))
+  const require = create(rootFile)
   return require(name)
 }
 


### PR DESCRIPTION
We previously had a fabricated file name (`_`) to forcefully resolve a
given directory path to a file path, so `createRequire` would be happy.

Since we now pass the file path every time, we no longer need this.

In future, if we need to `req` a directory, we should resolve the path
at the call-site rather than inside `req`.

### `Type`

- [x] Fix

### `SemVer`

- [x] Fix (:label: Patch)

### `Issues`

Fixes the problems mentioned in #229.

---

@ai we really should add some tests for the various ways things can be resolved. could you help with that some time as i dont fully follow what is tested where yet.

basically some tests (if they dont exist already) to ensure we can have various types of paths to plugins (relative, absolute, etc).

