### PR TITLE
fix: Convert paths to fix ERR_UNSUPPORTED_ESM_URL_SCHEME errors on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const resolve = require('path').resolve
+const url = require('url')
 
 const config = require('lilconfig')
 const yaml = require('yaml')
@@ -67,7 +68,7 @@ const createContext = (ctx) => {
 }
 
 const importDefault = async filepath => {
-  const module = await import(filepath)
+  const module = await import(url.pathToFileURL(filepath).href)
   return module.default
 }
 


### PR DESCRIPTION
### `Notable Changes`

Uses `url.pathToFileURL` when loading using `await import()`, because that only supports URLs. It worked coincidentally on Linux and MacOS, because they use the same path separator as URLs (`/`).

#### `Commit Message Summary (CHANGELOG)`

```
fix: Convert paths to fix ERR_UNSUPPORTED_ESM_URL_SCHEME errors on Windows
```

### `Type`

<!-- ℹ️  What types of changes does your code introduce? -->

<!-- 👉 Put an `x` in the boxes that apply and delete all others -->

- [ ] CI
- [X] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Style
- [ ] Build
- [ ] Feature
- [ ] Refactor

### `SemVer`

<!-- ℹ️  What changes to the current `semver` range does your PR introduce? -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [X] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Issues`

<!-- ℹ️ What issue(s) (if any) are closed by your PR? -->

<!-- 👉  Replace `#1` with the issue number that applies and remove the ``` ` ``` -->

- Fixes #237.

### `Checklist`

<!-- ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [X] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
