### PR TITLE
fix: use different name than __require

### DIFF
--- a/src/req.js
+++ b/src/req.js
@@ -13,8 +13,7 @@ let jiti = null
  * @returns {Promise<any>}
  */
 async function req(name, rootFile = __filename) {
-  let __require = createRequire(rootFile)
-  let url = __require.resolve(name)
+  let url = createRequire(rootFile).resolve(name)
 
   try {
     return (await import(pathToFileURL(url).href)).default


### PR DESCRIPTION
### `Notable Changes`

Looks like some projects are using `__require` for patching stuff. We can avoid naming the variable here to avoid conflicts.

#### `Commit Message Summary (CHANGELOG)`

```
avoid using __require as a variable name
```

### `Type`

<!-- ℹ️  What types of changes does your code introduce? -->

<!-- 👉 Put an `x` in the boxes that apply and delete all others -->

- [ ] CI
- [ ] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Style
- [ ] Build
- [ ] Feature
- [ ] Refactor

### `SemVer`

<!-- ℹ️  What changes to the current `semver` range does your PR introduce? -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [ ] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### `Issues`

<!-- ℹ️ What issue(s) (if any) are closed by your PR? -->

<!-- 👉  Replace `#1` with the issue number that applies and remove the ``` ` ``` -->

- Fixes `#1`

### `Checklist`

<!-- ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code -->

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [ ] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
