### PR TITLE
chore: fix error assertions

### DIFF
--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -3,17 +3,23 @@ const { rejects } = require('node:assert')
 
 const postcssrc = require('../src/index.js')
 
-// FIXME: this is resolving to nearest postcss config (outside root)
-// test('Loading Config - {Error}', async () => {
-//   await rejects(() => postcssrc({}, 'test/err'), {
-//     message: /^No PostCSS Config found in: (.*)$/
-//   })
-// })
-
 describe('Loading Config - {Error}', () => {
-  test('no config found error', () => {
+  // FIXME: this is resolving to nearest postcss config (outside root)
+  // test('Missing File', async () => {
+  //   await rejects(() => postcssrc({}, 'test/err'), {
+  //     message: /^No PostCSS Config found in: (.*)$/
+  //   })
+  // })
+
+  test('Missing Directory', () => {
     return rejects(() => postcssrc({}, 'ghostDir'), {
       message: /^No PostCSS Config found in: (.*)$/
+    })
+  })
+
+  test('TS - Syntax', () => {
+    return rejects(() => postcssrc({}, 'test/err/ts'), {
+      message: /^(Transform failed|ParseError)/
     })
   })
 })
@@ -67,11 +73,5 @@ describe('Loading Options - {Error}', () => {
     return rejects(() => postcssrc({}, 'test/err/options/stringifier'), {
       message: /^Loading PostCSS Stringifier failed: .*$/m
     })
-  })
-})
-
-test('Loading TS Config - {Error} - Syntax', () => {
-  return rejects(() => postcssrc({}, 'test/err/ts'), {
-    message: /^(Transform failed|ParseError)/
   })
 })

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -4,13 +4,6 @@ const { rejects } = require('node:assert')
 const postcssrc = require('../src/index.js')
 
 describe('Loading Config - {Error}', () => {
-  // FIXME: this is resolving to nearest postcss config (outside root)
-  // test('Missing File', async () => {
-  //   await rejects(() => postcssrc({}, 'test/err'), {
-  //     message: /^No PostCSS Config found in: (.*)$/
-  //   })
-  // })
-
   test('Missing Directory', () => {
     return rejects(() => postcssrc({}, 'ghostDir'), {
       message: /^No PostCSS Config found in: (.*)$/

--- a/test/Errors.test.js
+++ b/test/Errors.test.js
@@ -1,68 +1,77 @@
 const { describe, test } = require('node:test')
-const { match } = require('node:assert')
+const { rejects } = require('node:assert')
 
 const postcssrc = require('../src/index.js')
 
-test('Loading Config - {Error}', () => {
-  return postcssrc({}, 'test/err').catch(err => {
-    match(err.message, /^No PostCSS Config found in: (.*)$/)
+// FIXME: this is resolving to nearest postcss config (outside root)
+// test('Loading Config - {Error}', async () => {
+//   await rejects(() => postcssrc({}, 'test/err'), {
+//     message: /^No PostCSS Config found in: (.*)$/
+//   })
+// })
+
+describe('Loading Config - {Error}', () => {
+  test('no config found error', () => {
+    return rejects(() => postcssrc({}, 'ghostDir'), {
+      message: /^No PostCSS Config found in: (.*)$/
+    })
   })
 })
 
 describe('Loading Plugins - {Error}', () => {
   test('Plugin - {Type} - Invalid', () => {
-    return postcssrc({}, 'test/err/plugins').catch(err => {
-      match(err.message, /^Invalid PostCSS Plugin found at: (.*)\n\n\(@.*\)$/)
+    return rejects(() => postcssrc({}, 'test/err/plugins'), {
+      message: /^Invalid PostCSS Plugin found at: (.*)\n\n\(@.*\)$/
     })
   })
 
   test('Plugin - {Object}', () => {
-    return postcssrc({}, 'test/err/plugins/object').catch(err => {
-      match(err.message, /^Loading PostCSS Plugin failed: .*$/m)
+    return rejects(() => postcssrc({}, 'test/err/plugins/object'), {
+      message: /^Loading PostCSS Plugin failed: .*$/m
     })
   })
 
   test('Plugin - {Object} - Options', () => {
-    return postcssrc({}, 'test/err/plugins/object/options').catch(err => {
-      match(err.message, /^Loading PostCSS Plugin failed: .*$/m)
+    return rejects(() => postcssrc({}, 'test/err/plugins/object/options'), {
+      message: /^Loading PostCSS Plugin failed: .*$/m
     })
   })
 
   test('Plugin - {Array}', () => {
-    return postcssrc({}, 'test/err/plugins/array').catch(err => {
-      match(err.message, /^Cannot find (.*)$/m)
+    return rejects(() => postcssrc({}, 'test/err/plugins/array'), {
+      message: /^Cannot find (.*)$/m
     })
   })
 
   test('Plugin - {Array} - Options', () => {
-    return postcssrc({}, 'test/err/plugins/array/options').catch(err => {
-      match(err.message, /^Cannot find (.*)$/m)
+    return rejects(() => postcssrc({}, 'test/err/plugins/array/options'), {
+      message: /^Cannot find (.*)$/m
     })
   })
 })
 
 describe('Loading Options - {Error}', () => {
   test('Parser - {String}', () => {
-    return postcssrc({}, 'test/err/options/parser').catch(err => {
-      match(err.message, /^Loading PostCSS Parser failed: .*$/m)
+    return rejects(() => postcssrc({}, 'test/err/options/parser'), {
+      message: /^Loading PostCSS Parser failed: .*$/m
     })
   })
 
   test('Syntax - {String}', () => {
-    return postcssrc({}, 'test/err/options/syntax').catch(err => {
-      match(err.message, /^Loading PostCSS Syntax failed: .*$/m)
+    return rejects(() => postcssrc({}, 'test/err/options/syntax'), {
+      message: /^Loading PostCSS Syntax failed: .*$/m
     })
   })
 
   test('Stringifier - {String}', () => {
-    return postcssrc({}, 'test/err/options/stringifier').catch(err => {
-      match(err.message, /^Loading PostCSS Stringifier failed: .*$/m)
+    return rejects(() => postcssrc({}, 'test/err/options/stringifier'), {
+      message: /^Loading PostCSS Stringifier failed: .*$/m
     })
   })
 })
 
 test('Loading TS Config - {Error} - Syntax', () => {
-  return postcssrc({}, 'test/err/ts').catch(err => {
-    match(err.message, /^(Transform failed|ParseError)/)
+  return rejects(() => postcssrc({}, 'test/err/ts'), {
+    message: /^(Transform failed|ParseError)/
   })
 })

--- a/test/rc.test.js
+++ b/test/rc.test.js
@@ -54,12 +54,3 @@ test('.postcssrc - {Object} - Process SSS', () => {
       })
   })
 })
-
-describe('Load Config Error', () => {
-  test('no config found error', () => {
-    return postcssrc({}, 'ghostDir')
-    .catch(error => {
-      equal(error.message.startsWith("No PostCSS Config found in:"), true)
-    })
-  })
-})


### PR DESCRIPTION
### `Notable Changes`

`.catch` + `match`/`equals` doesn't assert that a particular call throws error. It just asserts IF an error is thrown it will satisfy assertions inside. Consequently, it will pass the test even if something doesn't throw while it should.

### `Type`

- [x] Test
- [x] Chore

### `SemVer`

- [ ] No bump needed

### `Checklist`

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
