### PR TITLE
docs: fix environment spelling in DOCS

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -52,7 +52,7 @@ Load Config
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | cwd | <code>String</code> | <code>process.cwd()</code> | Config search start location |
-| env | <code>String</code> | <code>process.env.NODE_ENV</code> | Config Enviroment, will be set to `development` by `postcss-load-config` if `process.env.NODE_ENV` is `undefined` |
+| env | <code>String</code> | <code>process.env.NODE_ENV</code> | Config environment, will be set to `development` by `postcss-load-config` if `process.env.NODE_ENV` is `undefined` |
 
 <a name="rc..path"></a>
 
@@ -69,4 +69,3 @@ Load Config
 | Name | Type | Default |
 | --- | --- | --- |
 | rcExtensions | <code>Boolean</code> | <code>true</code> | 
-


### PR DESCRIPTION
## Summary
- Correct `Enviroment` to `environment` in the generated docs table.

## Related issue
- N/A

## Guideline alignment
- Read the contribution guide where present and kept this to one focused text-only file change.
- No behavior, test, fixture, changelog, or generated-file changes.

## Validation
- `git diff --check`
- Not run: broader tests are unnecessary for this text-only change.

## AI assistance
- Prepared with Codex and reviewed before submission.
